### PR TITLE
Fix review auth token validation

### DIFF
--- a/BackEnd/controllers/authController.js
+++ b/BackEnd/controllers/authController.js
@@ -5,7 +5,7 @@ const DAO = require('../models/dao');
 const dao = new DAO();
 const db = dao.getDb();
 
-const SECRET = 'CLAVESECRETA';
+const SECRET = process.env.JWT_SECRET || 'CLAVESECRETA';
 
 function generarToken(usuario) {
   return jwt.sign({ id: usuario.id, nombre: usuario.nombre, rol: usuario.rol }, SECRET, { expiresIn: '2h' });

--- a/BackEnd/middlewares/auth.js
+++ b/BackEnd/middlewares/auth.js
@@ -2,11 +2,16 @@ const jwt = require('jsonwebtoken');
 const DAO = require('../models/dao');
 const db = new DAO().getDb();
 
-const JWT_SECRET = process.env.JWT_SECRET || 'tu_clave_secreta_aqui';
+const JWT_SECRET = process.env.JWT_SECRET || 'CLAVESECRETA';
+
+function getToken(req) {
+  const header = req.headers.authorization || '';
+  const parts = header.split(' ');
+  return parts.length === 2 ? parts[1] : header;
+}
 
 module.exports = async (req, res, next) => {
-  const authHeader = req.headers.authorization || '';
-  const token = authHeader.replace(/^Bearer\s+/i, '');
+  const token = getToken(req);
 
   if (!token) {
     return res.status(401).json({ error: 'Falta token de autorización.' });

--- a/BackEnd/middlewares/authMiddleware.js
+++ b/BackEnd/middlewares/authMiddleware.js
@@ -1,8 +1,14 @@
 const jwt = require('jsonwebtoken');
-const SECRET = 'CLAVESECRETA';
+const SECRET = process.env.JWT_SECRET || 'CLAVESECRETA';
+
+function getToken(req) {
+  const header = req.headers.authorization || '';
+  const parts = header.split(' ');
+  return parts.length === 2 ? parts[1] : header;
+}
 
 module.exports = (req, res, next) => {
-  const token = req.headers.authorization?.split(" ")[1];
+  const token = getToken(req);
   if (!token) return res.status(401).json({ error: 'Token no proporcionado' });
 
   try {


### PR DESCRIPTION
## Summary
- handle "Bearer" prefix consistently across auth middlewares
- use helper to parse token from the Authorization header

## Testing
- `npm -C BackEnd test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b4f1f710083219d9f50e730806aa8