### PR TITLE
Fix auth error handling for reviews

### DIFF
--- a/BackEnd/middlewares/auth.js
+++ b/BackEnd/middlewares/auth.js
@@ -14,7 +14,7 @@ module.exports = async (req, res, next) => {
 
   try {
     const payload = jwt.verify(token, JWT_SECRET);
-    
+
     const row = await db.oneOrNone('SELECT nombre FROM "Usuario" WHERE id = $1', [payload.id]);
     if (!row) {
       return res.status(401).json({ error: 'Usuario no encontrado.' });
@@ -28,7 +28,10 @@ module.exports = async (req, res, next) => {
 
     next();
   } catch (err) {
-    console.error('JWT Error:', err);
-    return res.status(401).json({ error: 'Token inválido o expirado.' });
+    console.error('Auth error:', err);
+    if (err.name === 'JsonWebTokenError' || err.name === 'TokenExpiredError') {
+      return res.status(401).json({ error: 'Token inválido o expirado.' });
+    }
+    return res.status(500).json({ error: 'Error al validar token.' });
   }
 };


### PR DESCRIPTION
## Summary
- handle database errors separately in auth middleware

## Testing
- `node BackEnd/app.js > /tmp/app.log &`
- `curl -X POST http://localhost:3005/api/resenas -H 'Content-Type: application/json' -H 'Authorization: Bearer abc123' -d '{"lugar_id":"123","puntuacion":5,"comentario":"prueba"}'`


------
https://chatgpt.com/codex/tasks/task_e_684c4d6e3ba08321875e40935d4cb06a